### PR TITLE
Fixed 'show_ui'

### DIFF
--- a/src/data/taxonomies.json
+++ b/src/data/taxonomies.json
@@ -6,6 +6,7 @@
     "types": [
       "post"
     ],
+    "visibility": { "show_ui": [] },
     "hierarchical": true,
     "rest_base": "categories",
     "_links": {
@@ -35,6 +36,7 @@
     "types": [
       "post"
     ],
+    "visibility": { "show_ui": [] },
     "hierarchical": false,
     "rest_base": "tags",
     "_links": {

--- a/src/data/taxonomies.json
+++ b/src/data/taxonomies.json
@@ -6,7 +6,7 @@
     "types": [
       "post"
     ],
-    "visibility": { "show_ui": [] },
+    "visibility": { "show_ui": true },
     "hierarchical": true,
     "rest_base": "categories",
     "_links": {
@@ -36,7 +36,7 @@
     "types": [
       "post"
     ],
-    "visibility": { "show_ui": [] },
+    "visibility": { "show_ui": true },
     "hierarchical": false,
     "rest_base": "tags",
     "_links": {

--- a/src/pages/editor.js
+++ b/src/pages/editor.js
@@ -45,7 +45,7 @@ class Editor extends React.Component {
     data.dispatch('core/nux').disableTips();
 
     // Initialize the editor
-    window._wpLoadGutenbergEditor = new Promise(resolve => {
+    window._wpLoadBlockEditor = new Promise(resolve => {
       domReady(() => {
         resolve(editPost.initializeEditor('editor', postType, 1, settings, {}));
       });


### PR DESCRIPTION
TypeError: Cannot read property 'show_ui' of undefined
    at http://localhost:3000/vendor/gutenberg/editor/index.js:17:113849
    at i (https://unpkg.com/lodash@4.17.11/lodash.min.js:6:91)
    at An.filter (https://unpkg.com/lodash@4.17.11/lodash.min.js:99:338)
    at http://localhost:3000/vendor/gutenberg/editor/index.js:17:113814
    at Td (https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js:82:11)
    at hi (https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js:102:385)
    at Qg (https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js:144:293)
    at Rg (https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js:145:168)
    at Sc (https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js:158:109)
    at Z (https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js:156:492)
    at Kc (https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js:155:69)
    at ya (https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js:153:185)
    at hg (https://unpkg.com/react-dom@16.8.6/umd/react-dom.production.min.js:87:497)
    at t (http://localhost:3000/vendor/gutenberg/data/index.js:1:17294)
    at http://localhost:3000/vendor/gutenberg/data/index.js:1:17379
    at http://localhost:3000/vendor/gutenberg/data/index.js:1:13327
    at Array.forEach (<anonymous>)
    at o (http://localhost:3000/vendor/gutenberg/data/index.js:1:13300)
    at http://localhost:3000/vendor/gutenberg/data/index.js:1:11838
    at Object.p [as dispatch] (http://localhost:3000/vendor/gutenberg/data/index.js:1:5511)
    at e (<anonymous>:1:40553)
    at http://localhost:3000/vendor/gutenberg/redux-routine/index.js:1:3671
    at http://localhost:3000/vendor/gutenberg/data/index.js:1:6895
    at http://localhost:3000/vendor/gutenberg/data/index.js:1:7326
    at dispatch (http://localhost:3000/vendor/gutenberg/data/index.js:1:6413)
    at http://localhost:3000/vendor/gutenberg/redux-routine/index.js:1:3301
    at http://localhost:3000/vendor/gutenberg/redux-routine/index.js:1:7823
    at Array.some (<anonymous>)
    at n (http://localhost:3000/vendor/gutenberg/redux-routine/index.js:1:7799)
    at http://localhost:3000/vendor/gutenberg/redux-routine/index.js:1:7752